### PR TITLE
Add flags to disable colour output

### DIFF
--- a/vfetch.v
+++ b/vfetch.v
@@ -504,6 +504,7 @@ fn main() {
 	fp.skip_executable()
 	should_get_song := fp.bool('song', `s`, false, 'Print current playing music, works with Apple Music')
 	custom_image := fp.string('image', `i`, '', 'Display custom image, only works with kitty terminal')
+	hide_colour_strip := fp.bool('no-colour-demo', 0, false, 'Hide the colour demo strip')
 	no_colour_mode := fp.bool('no-colour', `c`, false, 'Disables colour formatting')
 
 	mut sys := new_system()?


### PR DESCRIPTION
This adds two flags:
- `--no-colour-demo` turns off the colour demo swatch,
- `--no-colour` turns off colour-formatted output and also implies `--no-colour-demo` because coloured squares don't make sense without colour